### PR TITLE
Changes to Temperature and Redshift Files

### DIFF
--- a/src/ObsTempScript.jl
+++ b/src/ObsTempScript.jl
@@ -11,8 +11,8 @@ m = CarterMethodBL(M=1.0, a=0.0)
 # observer position
 u = [0.0, 1000.0, deg2rad(85.0), 0.0]
 
-M_BH = m.M
-a_star = m.a
+M_BH = m.M*1 #defining mass (kg)
+a_star = m.a 
 
 R_isco = AccretionFormulae.r_isco(a_star, M_BH)
 
@@ -56,5 +56,8 @@ img = @time rendergeodesics(
 )
 
 # plot
-heatmap(reverse(img, dims=1))
+new_img = reverse(img, dims=1)
+new_img ./= 1e14
 
+heatmap(new_img)
+title!("Temperature (10^14)")

--- a/src/ObsTempScript.jl
+++ b/src/ObsTempScript.jl
@@ -1,0 +1,60 @@
+using GeodesicRendering
+using AccretionGeometry
+using CarterBoyerLindquist
+using AccretionFormulae
+
+using Plots
+gr()
+
+m = CarterMethodBL(M=1.0, a=0.0)
+
+# observer position
+u = [0.0, 1000.0, deg2rad(85.0), 0.0]
+
+M_BH = m.M
+a_star = m.a
+
+R_isco = AccretionFormulae.r_isco(a_star, M_BH)
+
+# disc has inner radius 10, outer radius 50, perpendicular to the spin axis
+d = GeometricThinDisc(R_isco, 50.0, deg2rad(90.0))
+
+# wrapper around the redshift function
+function redshift(m, sol, max_time; kwargs...)
+    u = sol.u[end] 
+    AccretionFormulae.regular_pdotu_inv(u, sol.prob.p, m)
+end
+
+function temperature(m, sol, max_time; kwargs...)
+    g = redshift(m, sol, max_time; kwargs...)
+
+    u = sol.u[end]
+
+    temperature = AccretionFormulae.temp_obs(u[2], a_star, M_BH, g)
+    # @show(temperature)
+end
+
+
+# create and compose the ValueFunction
+redshift_vf = (
+    # calculate redshift
+    ValueFunction(temperature)
+    # filter only pixels with r > 9, i.e. on the disc
+    ∘ FilterValueFunction((m, sol, max_time; kwargs...) -> sol.u[end][2] > R_isco, NaN)
+    # filter only pixels that terminated early (i.e., intersected with something)
+    ∘ ConstValueFunctions.filter_early_term
+)
+
+# do the render
+img = @time rendergeodesics(
+    m, u, 2000.0, 
+    d, 
+    fov_factor=3.3, abstol=1e-9, reltol=1e-9,
+    image_width = 350,
+    image_height = 250,
+    vf =redshift_vf
+)
+
+# plot
+heatmap(reverse(img, dims=1))
+

--- a/src/emission_profile.jl
+++ b/src/emission_profile.jl
@@ -1,0 +1,78 @@
+#imports
+using Plots
+
+#functions
+"""
+From Reynolds (2020) (Eq2-4)
+Calculates the radius of the inner most stable circular orbit of the a black hole,
+with spin a_star, and mass M.
+"""
+function r_isco(a_star, M)
+    
+    a = a_star
+    r_g = M
+    z1 = 1+∛(1-a^2)*(∛(1+a)+∛(1-a))
+    z2 = √(3*a^2+z1^2)
+    if a >= 0
+        r_isco = (3+z2-√((3-z1)*(3+z1+2*z2)))*r_g
+    elseif a < 0
+        r_isco = (3+z2+√((3-z1)*(3+z1+2*z2)))*r_g
+    end
+end
+
+"""
+From Page & Thorne (1974) (Eq15n)
+Calculates the function f at radius r, for a black hole of spin a_star, and mass M, 
+which is used to calculate the flux given by its accretion disk.
+"""
+function f(r, a_star, M)
+
+    R_isco = r_isco(a_star, M)
+  
+    x = √(r/M)
+    x0 = √(R_isco/M)
+    x1 = 2*cos((1/3)*(acos(a_star))-(π/3))
+    x2 = 2*cos((1/3)*(acos(a_star))+(π/3))
+    x3 = -2*cos((1/3)*(acos(a_star)))
+
+    f = (3/(2*M))*(1/(x^2*(x^3-(3*x)+(2*a_star))))*(x-x0-((3/2)*a_star*log(x/x0)) 
+            - (3*(x1-a_star)^2)/(x1*(x1-x2)*(x1-x3))*log((x-x1)/(x0-x1)) 
+            - (3*(x2-a_star)^2)/(x2*(x2-x1)*(x2-x3))*log((x-x2)/(x0-x2)) 
+            - (3*(x3-a_star)^2)/(x3*(x3-x1)*(x3-x2))*log((x-x3)/(x0-x3)))
+end
+
+function diss(mdot, r, a_star, M)
+    diss = ((c^6)/(G^2))*mdot*f(r, a_star, M)/(4*π*r)
+end
+
+function mdot(M)
+    L_edd = 3e4*L_☼*(M/M_☼)
+    Mdot = L_edd/(c^2*η)
+    mdot = 0.1*Mdot
+end
+
+function temp(r, a_star, M)
+    m_dot = mdot(M)
+    temp = (diss(m_dot, r, a_star, M)/σ_SB)^(1/4)
+end
+
+"""
+From Fanton et al. (1997) (Eq78)
+"""
+function temp_obs(r, a_star, M, g)
+    T = temp(r, a_star, M)
+    temp_obs = g*T
+end
+
+# constants
+G = 6.67e-11
+c = 3e8
+L_☼ = 3.8e26
+M_☼ = 1.99e30
+σ_SB = 5.67e-8
+
+η = 0.1
+# M = 10*M_☼
+# a_star = 0.1
+
+export temp_obs, r_isco


### PR DESCRIPTION
“emisssion_profile.jl”:

The current version seems to have some of the errors we previously fixed, such as: `r_isco` function incorrectly defined, and the being `temp_obs` and `r_isco` function not being exported correctly.

Additional changes are removing the negative sign from the `Mdot` equation, which previously seemed to be necessary to invert the temperature line profile the correct way round, but is no longer the required. Furthermore, removing this negative appears to have solved the issue of getting negative values inside our temperature function and as such we no longer need to take the absolute value of our temperature before taking the quarter power.

Finally, upon re-checking the units following the changes made to the `r_isco` function, namely changing the value of `r_g` into gravitational units (M), dimensional analysis suggested the resulting flux required a conversion factor of `c^6/G^2`. This would convert the flux obtained from using gravitational units which gives flux in `1/MT` to SI units where flux is `M/T^3`. Testing this with our line temperature profile using “Rel_PT_Emission Profile.jl” we obtained a black hole with temperature of order `10^6` for a `10` solar mass black hole which is certainly reasonable.

“Rel_PT_Emission Profile.jl”:

Changes include corrections to the `r_isco` function and flux conversion factor from gravitational to SI units.


“ObsTempScript.jl”:

This is a script to obtain a plot of the observed temperature profile. It runs for a mass of `1`, but seems to give incorrect temperatures.