### PR TITLE
Plunging Region

### DIFF
--- a/src/AccretionFormulae.jl
+++ b/src/AccretionFormulae.jl
@@ -2,7 +2,7 @@ module AccretionFormulae
 
 import GeodesicBase
 import GeodesicBase: AbstractMetricParams
-import CarterBoyerLindquist: CarterMethodBL, Σ, Δ, A
+import CarterBoyerLindquist: CarterMethodBL, Σ, Δ, A, rms, Σδr_δλ
 
 using GeodesicRendering: ValueFunction
 


### PR DESCRIPTION
## New

- plunging region redshift calculations for Carter and 2nd order methods; regime determined by the isco

## Changes

- 2nd order method doesn't need to calculate energy and momentum, as it was used just to calculate the velocity components again


The reason just using the velocity outright initially didn't work is related to https://github.com/astro-group-bristol/GeodesicBase.jl/pull/4 and the sign convention between integrating forwards and backwards.

## Examples

```julia
using GeodesicRendering
using AccretionGeometry
using AccretionFormulae
using ComputedGeodesicEquations
using StaticArrays

using Plots
gr()

u = @SVector [0.0, 1000.0, deg2rad(85.0), 0.0]
d = GeometricThinDisc(1.0, 50.0, deg2rad(90.0))


M = 1.0
a = 0.0
m = BoyerLindquist(M, a)

redshift_vf = (
    AccretionFormulae.redshift
    ∘ FilterValueFunction((m, sol, max_time; kwargs...) -> sol.retcode == :Intersected, NaN)
)

img = @time rendergeodesics(
    m, u, 2000.0, 
    d, 
    fov_factor=3.0*2, abstol=1e-9, reltol=1e-9,
    image_width = 350*2,
    image_height = 250,
    vf = redshift_vf
)

hm = heatmap(img, aspect_ratio = 1, ylims=(0, 250), size=(800, 300))
title!("M=$M, a=$a")
hm
```

![m-1-a--1](https://user-images.githubusercontent.com/11492844/155854710-ba385359-6478-43b6-8d60-01019f318249.png)
![m-1-a-0](https://user-images.githubusercontent.com/11492844/155854711-d1057b86-af73-4132-8241-d0285599d30c.png)
![m-1-a-1](https://user-images.githubusercontent.com/11492844/155854712-0e4fbb79-bef5-44ca-83f8-6216a6e8c486.png)

