### PR TITLE
Fixed Previous PR

### DIFF
--- a/src/emission_profile.jl
+++ b/src/emission_profile.jl
@@ -1,7 +1,3 @@
-#imports
-using Plots
-# using CarterBoyerLindquist
-
 #functions
 """
 From Reynolds (2020) (Eq2-4)

--- a/src/emission_profile.jl
+++ b/src/emission_profile.jl
@@ -1,5 +1,6 @@
 #imports
 using Plots
+# using CarterBoyerLindquist
 
 #functions
 """
@@ -8,14 +9,16 @@ Calculates the radius of the inner most stable circular orbit of the a black hol
 with spin a_star, and mass M.
 """
 function r_isco(a_star, M)
+    # M *= 1.99e30
     a = a_star
     r_g = 2*G*M/(c^2)
+    # r_g = 1
     z1 = 1+∛(1-a^2)*(∛(1+a)+∛(1-a))
     z2 = √(3*a^2+z1^2)
     if a >= 0
-        r_isco = (3+z2-(3-z1)*√(3+z1+2*z2))*r_g
+        r_isco = (3+z2-√((3-z1)*(3+z1+2*z2)))*r_g
     elseif a < 0
-        r_isco = (3+z2+(3-z1)*√(3+z1+2*z2))*r_g
+        r_isco = (3+z2+√((3-z1)*(3+z1+2*z2)))*r_g
     end
 end
 
@@ -24,43 +27,43 @@ From Page & Thorne (1974) (Eq15n)
 Calculates the function f at radius r, for a black hole of spin a_star, and mass M, 
 which is used to calculate the flux given by its accretion disk.
 """
-function f(r, a_star, M)
+function flux(r, a_star, M)
 
     R_isco = r_isco(a_star, M)
-  
     x = √(r/M)
     x0 = √(R_isco/M)
     x1 = 2*cos((1/3)*(acos(a_star))-(π/3))
     x2 = 2*cos((1/3)*(acos(a_star))+(π/3))
     x3 = -2*cos((1/3)*(acos(a_star)))
 
-    f = (3/(2*M))*(1/(x^2*(x^3-(3*x)+(2*a_star))))*(x-x0-((3/2)*a_star*log(x/x0)) 
+    flux = (3/(2*M))*(1/(x^2*(x^3-(3*x)+(2*a_star))))*(x-x0-((3/2)*a_star*log(x/x0)) 
             - (3*(x1-a_star)^2)/(x1*(x1-x2)*(x1-x3))*log((x-x1)/(x0-x1)) 
             - (3*(x2-a_star)^2)/(x2*(x2-x1)*(x2-x3))*log((x-x2)/(x0-x2)) 
             - (3*(x3-a_star)^2)/(x3*(x3-x1)*(x3-x2))*log((x-x3)/(x0-x3)))
 end
 
-function diss(mdot, r, a_star, M)
-    diss = mdot*f(r, a_star, M)/(4*π*r)
-end
-
 function mdot(M)
     L_edd = 3e4*L_☼*(M/M_☼)
     Mdot = -L_edd/(c^2*η)
-    mdot = 0.1*Mdot
+    mdot = -0.1*Mdot
 end
 
-function temp(r, a_star, M)
+function diss(mdot, r, a_star, M)
+    # diss = ((c^6)/(G^2))*mdot*f(r, a_star, M)/(4*π*r)
+    diss = mdot*flux(r, a_star, M)/(4*π*r)
+end
+
+function temperature(r, a_star, M)
     m_dot = mdot(M)
-    temp = abs(diss(m_dot, r, a_star, M)/σ_SB)^(1/4)
+    temperature = (diss(m_dot, r, a_star, M)/σ_SB)^(1/4)
 end
 
 """
 From Fanton et al. (1997) (Eq78)
 """
-function temp_obs(r, a_star, M, g)
-    T = temp(r, a_star, M)
-    temp_obs =  g*T
+function observed_temperature(r, a_star, M, g)
+    T = temperature(r, a_star, M)
+    observed_temperature =  g*T
 end
 
 # constants
@@ -74,8 +77,4 @@ M_☼ = 1.99e30
 # M = 10*M_☼
 # a_star = 0.1
 
-module EmissionProfile
-
-export temp_obs, r_isco
-
-end
+export observed_temperature, r_isco

--- a/src/temperature_render.jl
+++ b/src/temperature_render.jl
@@ -1,0 +1,67 @@
+using GeodesicRendering
+using AccretionGeometry
+using CarterBoyerLindquist
+using .AccretionFormulae
+using StaticArrays
+
+using Plots
+gr()
+
+m = CarterMethodBL(M=1.0, a=0.998)
+
+# observer position
+u = [0.0, 1000.0, deg2rad(85.0), 0.0]
+R_isco = AccretionFormulae.r_isco(m.a, m.M)
+
+# new method using the CarterBoyerLindquist RMS gave very different values
+# and wasn't working:
+# R_isco = CarterBoyerLindquist.rms(m.M, m.a)
+
+# disc has inner radius 10, outer radius 50, perpendicular to the spin axis
+d = GeometricThinDisc(R_isco, 50.0, deg2rad(90.0))
+
+# wrapper around the redshift function
+function redshift(m, sol, max_time; kwargs...)
+    u = sol.u[end] 
+    AccretionFormulae.regular_pdotu_inv(u, sol.prob.p, m)
+end
+
+function temperature(m, sol, max_time; kwargs...)
+    g =  redshift(m, sol, max_time; kwargs...)
+
+    u = sol.u[end]
+
+    M = m.M*1.99e30
+    # M = 5.0
+    a = m.a
+    a_star = a/M
+    temperature = AccretionFormulae.observed_temperature(u[2], a_star, M, g)
+end
+
+# create and compose the ValueFunction
+redshift_vf = (
+    # calculate redshift
+    ValueFunction(temperature)
+    # filter only pixels with r > 9, i.e. on the disc
+    ∘ FilterValueFunction((m, sol, max_time; kwargs...) -> sol.u[end][2] > R_isco, NaN)
+    # filter only pixels that terminated early (i.e., intersected with something)
+    ∘ ConstValueFunctions.filter_early_term
+)
+
+# do the render
+img = @time rendergeodesics(
+    m, u, 2000.0, 
+    d, 
+    fov_factor=3.0, abstol=1e-9, reltol=1e-9,
+    image_width = 350,
+    image_height = 250,
+    vf =redshift_vf
+)
+
+# plot
+scale = 1e4
+new_img = reverse(img, dims=1)
+new_img ./= scale
+
+heatmap(new_img)
+title!("Temperature $scale, $(m.M)")


### PR DESCRIPTION
This PR should only have changes to `emission_profile.jl` and the new `temperature_render.jl`. I've fixed a few of the issues you've highlighted, but the `.` is still present in `temperature_render.jl` as I mentioned in my [reply](https://github.com/astro-group-bristol/AccretionFormulae.jl/pull/17#discussion_r816957529). Unfortunately these are running into some issues with the new changes to `redshift.jl` and/or `AccretionFormulae.jl`, as they are only working when the old versions I have saved on my machine (and I think was going trying to add yesterday) are loaded. I think the problem is with the new `redshift.jl` being used, as if the `AccretionFormulae.jl` file is exactly the same as the working version, it is still broken. [Here's](https://pastebin.com/agkWZVvV) the error message if that could help debug.

I can't get any images from this obviously, but here's what the working version gets me:

![Plot](https://user-images.githubusercontent.com/94124028/156211814-00fcd201-3052-45e9-b35c-e6472b4b343f.png)

