### PR TITLE
Automatic Circular Orbit Discovery

### DIFF
--- a/scripts/alt-emissivity-deviations.jl
+++ b/scripts/alt-emissivity-deviations.jl
@@ -1,0 +1,122 @@
+"""
+Uses `hunting-circular-orbits.jl` and the Page & Thorne (1974) eq. (12)
+to simulate a flux model.
+
+Works for a < 0.97, then the orbit finder starts to panic close to the ISCO.
+"""
+
+# using Revise
+
+using GeodesicTracer
+using ComputedGeodesicEquations
+using GeodesicBase
+
+import CarterBoyerLindquist # for rms function
+import LinearAlgebra
+
+using StaticArrays
+using Plots
+gr()
+
+# hoist other functions
+include("hunting-circular-orbits.jl")
+
+# for Kerr, this is just `u[2]`, but to illustrate
+# how you could do this for other metrics
+function sqrt_g_tilde(m, u)
+    metric = GeodesicBase.metric(m, u)
+    metric_no_θ = metric[setdiff(1:4, 3), setdiff(1:4, 3)]
+
+    sqrt(-LinearAlgebra.det(metric_no_θ))
+end
+
+# gradient function
+#
+# we just compute discrete derivatives, since this is
+# sufficient when we have small `r`.
+# using interpolations can make the resolution better
+# and increase the accuracy, but this is a good quick-and-dirty way
+# to see if our results are going in the right direction
+function ∇r(array, r)
+    deriv = diff(array) ./ diff(r)
+    # ensure same dimension using a lazy extension
+    push!(deriv, deriv[end])
+    deriv
+end
+
+"""
+    f_approx(Lz, ∇rwt, ∇rLz_array, wt_array)
+
+A discretized version of `f` from Page & Thorne (1974) eq. (12):
+
+```math
+f(r_n) \\approx - \\left. \\left[
+   \\frac{1}{L_z} \\left(\\frac{\\partial \\dot{u}^t}{\\partial r} \\right)
+\\right] \\right\\rvert_{r = r_n} 
+\\sum_{i=0}^{n} \\left\\{ \\left. \\left[
+   \\frac{1}{\\dot{u}^t} \\left( \\frac{\\partial L_z}{\\partial r}\\right)
+\\right] \\right\\rvert_{r = r_i}
+\\right\\}
+```
+
+"""
+function f_approx(Lz, ∇rwt, ∇rLz_array, wt_array)
+    -(∇rwt / Lz) * sum(∇rLz_array ./ wt_array)
+end
+
+# use this to see where things break down / if they break down
+function plot_derivative_test(r_range, res)
+    lzs = res[:, 2]
+    # naive derivatives
+    derivs = ∇r(lzs, r_range)
+
+    plot(r_range, lzs, label = "Lz", c = :black, legend = false)
+    plot!(r_range, derivs, label = "derivative", c = :black, style = :dot, lw = 1.2)
+end
+
+
+# test plot
+function f_approx_test(r_range, res)
+    wts = res[:, 4]
+    Lzs = res[:, 2]
+
+    ∇rwt_array = ∇r(wts, r_range)
+    ∇rLz_array = ∇r(Lzs, r_range)
+
+    fs = map(2:length(r_range)) do i
+        @views f_approx(Lzs[i], ∇rwt_array[i], ∇rLz_array[1:i], wts[1:i])
+    end
+
+    # we rescale here for a better comparison
+    fs = fs ./ maximum(fs)
+
+    # we lose a point, so select all but last `r_range`
+    # since our derivative function needs at least 2 points to work
+    plot(r_range[2:end], fs, c = :black, xlabel = "r", ylabel = "f", label = "simulated f")
+end
+
+# this works up until about 0.97 then, the orbit search
+# starts to break down
+m = BoyerLindquist(M = 1.0, a = 0.97)
+u = @SVector [0.0, 13.0, deg2rad(90), 0.0]
+
+println("Starting approximation...")
+
+# making the steps too big over-estimates the gradient
+r_range = CarterBoyerLindquist.rms(m.M, m.a):0.01:30.0
+res = find_orbit_range(; r_range = r_range, a = m.a)
+
+# use this to check if the derivatives are okay
+# plot_derivative_test(r_range, res)
+
+f_approx_test(r_range, res)
+println("Approximation done!")
+
+# compare to "true" value
+import AccretionFormulae
+f_true = AccretionFormulae.flux.(r_range, m.a, m.M)
+# rescale as well
+f_true = f_true ./ maximum(f_true)
+plot!(r_range, f_true, label = "true f")
+
+# savefig("simulated-f-not-log.svg")

--- a/scripts/hunting-circular-orbits.jl
+++ b/scripts/hunting-circular-orbits.jl
@@ -1,0 +1,136 @@
+"""
+This file defined functions using Optim.jl to automatically discover circular orbits with the `BoyerLindquist`
+metric parameters. This method is able to achieve approx 10^-9 numerical accuracy on the true E and Lz of a 
+circular orbit.
+"""
+
+# using Revise
+
+using GeodesicTracer
+using ComputedGeodesicEquations
+using GeodesicBase
+
+using StaticArrays
+using Optim
+
+using Plots
+
+# quality of stability function which has a minimum at stable orbits
+# this is just a sum of the normalised residuals
+Qs(rs) = sqrt(sum((rs ./ rs[1] .- 1.0).^2) / length(rs))
+
+# utility function for tracing a single orbit given some `vϕ`
+function trace_single_geodesic(m, u, vϕ)
+    v = @SVector [0.0, 0.0, 0.0, vϕ]
+    tracegeodesics(
+        m, u, v, 
+        # we pick a duration that is quite long
+        # but you can toy with this
+        # the method is pretty good for `r > r_isco` at even just
+        # (0.0, 30.0) for the affine time
+        (0.0, 1000.0), 
+        μ=1.0, 
+        # amazingly, we don't even need good tolerances
+        abstol=1e-8, 
+        reltol=1e-8,
+        # important, else it will spam your terminal
+        verbose=false
+    )
+end
+
+# a little utility method to we don't always have to specify `u` everywhere
+function geodesic_for(m, r_init, vϕ)
+    u = @SVector [0.0, r_init, deg2rad(90.0), 0.0]
+    trace_single_geodesic(m, u, vϕ)
+end
+
+# utility function which returns to stability after integrating a geodesic
+# for some trial `vϕ`
+function estimate_stability(m, u, vϕ)
+    sol = trace_single_geodesic(m, u, vϕ)
+    rs = selectdim(sol, 1, 6)
+    Qs(rs)
+end
+
+function find_vϕ_for_orbit(m, r_init; lower_bound=0.0, upper_bound=0.1)
+    u = @SVector [0.0, r_init, deg2rad(90.0), 0.0]
+    # here we use the Optim.jl library
+    res = optimize(
+        # use an anonymous function to wrap our stability estimator into a univariate function
+        vϕ -> estimate_stability(m, u, vϕ),
+        lower_bound,
+        upper_bound,
+        # there are to univariate solvers, the other being `Brent`, but
+        # personally I've found more success with `GoldenSection` (https://en.wikipedia.org/wiki/Golden-section_search)
+        # even though it is slower
+        GoldenSection()
+    )
+    # uncomment this to see information about each solve
+    # @show res 
+
+    # return the `vϕ` which minimized our function
+    Optim.minimizer(res)
+end
+
+
+# this uses a sliding window for the lower and upper bounds on the `vϕ` estimate
+# basically, if we overestimate the boundaries, the solution takes too many iterations and
+# doesn't converge, and if we miss the estimation, we risk excluding the true solution
+#
+# the sliding window uses the a priori knowledge that radii closer to the origin will have
+# greater `vϕ`, and so adjusts the lower and upper bounds accordingly (though still permits
+# slightly lower `vϕ` to avoid possible numerical errors)
+#
+# it seems to work pretty well, but you may need to adjust the upper bound a little
+# the tolerance is good to about a factor of 1000, so if your true velocity is 1 and you set
+# the bounds to 1000, you will still find it. setting it higher than this, e.g. 10_000 will
+# not converge in the set number of iterations
+function find_vϕ_for_orbit_range(m, rs; lower=0.0, upper=0.1)
+    lower = lower
+    upper = upper
+
+    # we solve backwards, from the furthest radii inwards
+    # so that we can use a asymptotically flat space guess for the window (which should be metric
+    # independent), and roll our way in from there
+    map(reverse(rs)) do r
+        vϕ = find_vϕ_for_orbit(m, r; lower_bound=lower, upper_bound=upper)
+        # continuously adjust based on heuristic
+        lower = vϕ * 0.9
+        upper = vϕ * 2.0
+        vϕ
+    # reverse again to make sure the order is correct
+    end |> reverse
+end
+
+
+# range is set from approx schwarzschild radius to whatever you like it to be
+# maybe it's best just to do from r_isco outwards?
+function find_orbit_range(;r_range = 2.0:0.1:10.0, a=-0.4, upper=0.1)
+    m = BoyerLindquist(M=1.0, a=a)
+    vϕs = @time find_vϕ_for_orbit_range(m, r_range; upper=upper)
+
+    # calculate the paths
+    geodesics = map(i -> geodesic_for(m, r_range[i], vϕs[i]), eachindex(r_range))
+    
+    # assemble a matrix of energies and angular momenta
+    # such that `e_lz[i, 1]` gives you the energy of geodesic `i``
+    e_lz = [f(m, geo.u[1].x[2], geo.u[1].x[1]) for geo in geodesics, f in (GeodesicBase.E, GeodesicBase.Lz)]
+
+    # join velocities as the last column
+    hcat(e_lz, vϕs)
+end
+
+
+# test function for a single radius
+# incase you want to trial indivial things
+function test_single(;r_init = 10.0, a=-0.4, upper=0.1)
+
+    m = BoyerLindquist(M=1.0, a=a)
+    vϕ = find_vϕ_for_orbit(m, r_init; upper_bound=upper)
+    sol = geodesic_for(m, r_init, vϕ)
+
+    plot(sol, vars=(8, 6), projection=:polar, range=(0.0, r_init))
+end
+
+
+find_orbit_range()


### PR DESCRIPTION
Added a (highly commented) script for discovering circular orbits using [Optim.jl](https://julianlsolvers.github.io/Optim.jl/stable/), able to find the energy and angular momentum of circular orbits to within 10^-9 of the true values for any given radius.

I've written a little blog post, some of which covers what this does [here](https://fjebaker.github.io/blog/pages/2022-03-circular-orbits/#automated_circular_orbit_discovery), where the method is evaluated against analytic results.

Example
```julia
include("scripts/hunting-circular-orbits.jl")
import CarterBoyerLindquist # for rms function

pl = plot()

m = BoyerLindquist(M=1.0, a=-0.5)
r_range = 3.0:1.0:13.0
vϕs = @time find_vϕ_for_orbit_range(m, r_range; upper=0.2)
geodesics = map(i -> geodesic_for(m, r_range[i], vϕs[i]), eachindex(r_range))

for sol in geodesics
    plot!(
        sol, 
        vars=(8, 6), 
        projection=:polar, 
        range=(0.0, last(r_range)), 
        legend=false
    )
end

plot!(
    _ -> GeodesicBase.inner_radius(m),
    0.0:0.01:2π,
    c=:black,
    lw=5
)
plot!(
    _ -> CarterBoyerLindquist.rms(m.M, m.a),
    0.0:0.01:2π,
    c=:black,
    lw=2,
    ls=:dot
)

pl
```

Produces:
![example_circs](https://user-images.githubusercontent.com/11492844/163212135-35746dee-166b-4971-a22b-8c176b1a0777.svg)

The dotted line is the ISCO, and the solid black line is the event horizon. The method is still able to find some unstable circular orbits even within the ISCO, though they deteriorate over long integration times.
